### PR TITLE
Fix compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 
 # local configuration options
-include ./local.mk
+-include ./local.mk
 
 
 # keep track of our current location

--- a/src/output.h
+++ b/src/output.h
@@ -17,8 +17,8 @@
 
 extern int output_level;
 
-inline void   output_version (void);
-inline void   output_help (void);
+void   output_version (void);
+void   output_help (void);
 
 void   output_debug (const char *format, ...);
 void   output_info (const char *format, ...);

--- a/src/parse.c
+++ b/src/parse.c
@@ -268,6 +268,7 @@ argdata_t *parse_commandline (int argc, char **argv)
 
     case '?':
       output_error ("Unrecognized option: '%c'", optopt);
+      __attribute__ ((fallthrough));
 
     default:
       output_help();

--- a/src/quota.h
+++ b/src/quota.h
@@ -110,7 +110,7 @@ void        quota_delete   (quota_t *myquota);
 int         quota_get      (quota_t *myquota);
 int         quota_set      (quota_t *myquota);
 
-int         xfs_reset_grace(quota_t *myquota, int grace_type);
+int         quota_reset_grace(quota_t *myquota, int grace_type);
 
 
 #endif /* INCLUDE_QUOTATOOL_QUOTA */


### PR DESCRIPTION
While preparing a new debian package (long overdue, I know...) I encountered a number of compiler warnings (see below) when compiling with gcc7 and `-Wall` `-Wextra`.  These patches fix those.

```
[bas@debian-sid](130)My-Packages/quotatool/quotatool-1.6.2> make CFLAGS="-Wall -Wextra"
gcc -Wall -Wextra  -I./src -I./src/linux -DHAVE_CONFIG_H  -c -o src/system.o src/system.c
In file included from src/system.c:51:
src/output.h:21:15: warning: inline function ‘output_help’ declared but never defined
 inline void   output_help (void);
               ^~~~~~~~~~~
src/output.h:20:15: warning: inline function ‘output_version’ declared but never defined
 inline void   output_version (void);
               ^~~~~~~~~~~~~~
gcc -Wall -Wextra  -I./src -I./src/linux -DHAVE_CONFIG_H  -c -o src/output.o src/output.c
gcc -Wall -Wextra  -I./src -I./src/linux -DHAVE_CONFIG_H  -c -o src/main.o src/main.c
src/main.c: In function ‘main’:
src/main.c:211:17: warning: implicit declaration of function ‘quota_reset_grace’; did you mean ‘xfs_reset_grace’? [-Wimplicit-function-declaration]
           if (! quota_reset_grace(quota, (argdata->block_reset ? GRACE_BLOCK : GRACE_INODE)))
                 ^~~~~~~~~~~~~~~~~
                 xfs_reset_grace
In file included from src/main.c:23:
src/main.c: At top level:
src/output.h:21:15: warning: inline function ‘output_help’ declared but never defined
 inline void   output_help (void);
               ^~~~~~~~~~~
src/output.h:20:15: warning: inline function ‘output_version’ declared but never defined
 inline void   output_version (void);
               ^~~~~~~~~~~~~~
gcc -Wall -Wextra  -I./src -I./src/linux -DHAVE_CONFIG_H  -c -o src/parse.o src/parse.c
In file included from src/parse.c:24:
src/output.h:21:15: warning: inline function ‘output_help’ declared but never defined
 inline void   output_help (void);
               ^~~~~~~~~~~
src/output.h:20:15: warning: inline function ‘output_version’ declared but never defined
 inline void   output_version (void);
               ^~~~~~~~~~~~~~
src/parse.c: In function ‘parse_commandline’:
src/parse.c:270:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
       output_error ("Unrecognized option: '%c'", optopt);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/parse.c:272:5: note: here
     default:
     ^~~~~~~
gcc -Wall -Wextra  -I./src -I./src/linux -DHAVE_CONFIG_H  -c -o src/linux/quota.o src/linux/quota.c
In file included from src/linux/quota.c:21:
./src/output.h:21:15: warning: inline function ‘output_help’ declared but never defined
 inline void   output_help (void);
               ^~~~~~~~~~~
./src/output.h:20:15: warning: inline function ‘output_version’ declared but never defined
 inline void   output_version (void);
               ^~~~~~~~~~~~~~
gcc -o quotatool ./src/system.o ./src/output.o ./src/main.o ./src/parse.o ./src/linux/quota.o    -Wall -Wextra
```