### PR TITLE
fix missing __P definition for musl compile

### DIFF
--- a/src/linux/linux_quota.h
+++ b/src/linux/linux_quota.h
@@ -14,6 +14,7 @@
 #ifndef LINUX_QUOTA_H
 #define LINUX_QUOTA_H
 
+#include <sys/cdefs.h>
 #include <sys/types.h>
 #include "system.h"
 


### PR DESCRIPTION
Fixes:

  In file included from src/quota.h:40:0,
                   from src/parse.c:26:
  src/linux/linux_quota.h:120:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘__P’
   long quotactl __P((int, const char *, qid_t, caddr_t));
                 ^~~

Signed-off-by: Peter Seiderer <ps.report@gmx.net>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/quotatool/0001-fix-missing-__P-definition-for-musl-compile.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>